### PR TITLE
Add Logger

### DIFF
--- a/Sources/Coordinator/Coordinators/Coordinating.swift
+++ b/Sources/Coordinator/Coordinators/Coordinating.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Base protocol that defines the shared behavior and identity requirements for all coordinators.
 @MainActor
-public protocol Coordinating: ObservableObject, Identifiable, Hashable, Equatable {
+public protocol Coordinating: ObservableObject, Identifiable, Hashable, Equatable, CustomStringConvertible {
 
     /// The unique identifier of the coordinator.
     nonisolated var id: String { get }
@@ -31,5 +31,15 @@ public extension Coordinating {
 
     nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+public extension Coordinating {
+
+    nonisolated var description: String {
+        let typeName = String(describing: Self.self)
+        return "\(typeName)(id: \"\(id)\")"
     }
 }

--- a/Sources/Coordinator/Coordinators/Modal/ModalCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Modal/ModalCoordinating.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 
 /// A protocol defining the requirements for coordinators that manage the presentation of modals.
 ///
@@ -53,13 +54,13 @@ public extension ModalCoordinating {
         switch presentationStyle {
         case .sheet:
             guard sheet == nil else {
-                print("A sheet is already presented on \(self), cannot present route as sheet")
+                Logger.coordinator.warning("Cannot present \"\(route)\" as sheet: \"\(self)\" is already presenting \"\(self.sheet!)\".")
                 return
             }
             sheet = route
         case .fullScreenCover:
             guard fullScreenCover == nil else {
-                print("A fullScreenCover is already presented on \(self), cannot present route as fullScreenCover")
+                Logger.coordinator.warning("Cannot present \"\(route)\" as fullScreenCover: \"\(self)\" is already presenting \"\(self.fullScreenCover!)\".")
                 return
             }
             fullScreenCover = route

--- a/Sources/Coordinator/Coordinators/Stack/RootStackCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/RootStackCoordinating.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 
 public protocol RootStackCoordinating: StackCoordinating {
 
@@ -51,13 +52,8 @@ public extension RootStackCoordinating {
     }
     
     /// Pops the top-most view from the navigation stack.
-    /// - This removes the last added route from the navigation path.
     func pop() {
-        guard !path.isEmpty else {
-            print("Root path is empty, cannot pop route")
-            return
-        }
-        path.removeLast()
+        popLast(1)
     }
     
     /// Pops all views from the navigation stack except the root view.
@@ -70,7 +66,7 @@ public extension RootStackCoordinating {
     /// - Parameter k: The number of views to pop, defaulting to `1`.
     func popLast(_ k: Int = 1) {
         guard path.count >= k else {
-            print("Root path contains \(path.count) elements, cannot pop \(k) routes")
+            Logger.coordinator.warning("\(self) cannot pop \(k) routes: path contains only \(self.path.count).")
             return
         }
         path.removeLast(k)
@@ -97,7 +93,7 @@ public final class RootStackCoordinator<Route: Routable>: RootStackCoordinating 
 	/// Initializes a new `RootCoordinator` with a given `Coordinator`.
 	/// - Parameter coordinator: The initial `Coordinator` that this root coordinator manages.
 	public init<C: StackCoordinating>(coordinator: C) where C.Route == Route {
-        self.id = "RootStackCoordinator<\(C.self)>"
+        self.id = "RootStackCoordinator<\(coordinator)>"
 		self.initialRoute = coordinator.initialRoute
         self.path = NavigationPath(coordinator.presentedRoutes)
 		coordinator.root = self

--- a/Sources/Coordinator/Coordinators/Stack/StackCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/StackCoordinating.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 
 /// A protocol defining the requirements for coordinators that manage a `NavigationStack`.
 ///
@@ -37,7 +38,7 @@ public extension StackCoordinating {
     /// - Parameter coordinator: The `Coordinator` to push.
     func push(coordinator: any StackCoordinating) {
         guard let root else {
-            print("Root is nil, cannot push coordinator")
+            Logger.coordinator.warning("Cannot push \"\(coordinator.description)\" from \"\(self)\": root is nil.")
             return
         }
         coordinator.root = root
@@ -48,7 +49,7 @@ public extension StackCoordinating {
     /// - Parameter route: The `Routable` instance to be pushed onto the stack.
     func push(route: Route) {
         guard let root else {
-            print("Root is nil, cannot push route")
+            Logger.coordinator.warning("Cannot push \"\(route)\" from \"\(self)\": root is nil.")
             return
         }
         root.push(route)
@@ -58,7 +59,7 @@ public extension StackCoordinating {
     /// Default implementation of `pop()`, removing the last item from the `NavigationPath`.
     func pop() {
         guard let root else {
-            print("Root is nil, cannot pop route")
+            Logger.coordinator.warning("Cannot pop from \"\(self)\": root is nil.")
             return
         }
         root.pop()
@@ -69,7 +70,7 @@ public extension StackCoordinating {
     /// Default implementation of `popToRoot()`, removing all items from the `NavigationPath`.
     func popToRoot() {
         guard let root else {
-            print("Root is nil, cannot pop to root")
+            Logger.coordinator.warning("Cannot pop to initial route from \"\(self)\": root is nil.")
             return
         }
         root.popLast(presentedRoutes.count)
@@ -83,10 +84,12 @@ public extension StackCoordinating {
     ///
     /// - Note: This method performs a root path check to ensure there are enough items to pop. Use this method instead of `pop()` or `popToRoot()` when you need to remove both the current stack and the previous route.
     func popToPrevious() {
-        guard let root,
-              root.path.count > presentedRoutes.count
-        else {
-            print("Root is nil, cannot pop to root")
+        guard let root else {
+            Logger.coordinator.warning("Cannot pop to previous coordinator from \"\(self)\": root is nil.")
+            return
+        }
+        guard root.path.count > presentedRoutes.count else {
+            Logger.coordinator.warning("Cannot pop to previous coordinator from \"\(self)\": routes inconsistent with root path.")
             return
         }
         root.popLast(presentedRoutes.count + 1)

--- a/Sources/Coordinator/Coordinators/TabView/TabViewCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/TabView/TabViewCoordinating.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 
 /// A protocol that defines the coordination logic for a tab-based navigation system.
 ///
@@ -41,7 +42,7 @@ public extension TabViewCoordinating {
     /// - Parameter tab: The tab to select.
     func select(_ tab: Route) {
         guard tabs.contains(tab) else {
-            print("Can't select tab: \(tab) since it's not registered in the Coordinator's tabs.")
+            Logger.coordinator.warning("Cannot select tab from \"\(self)\": \"\(tab)\" is unregistered.")
             return
         }
         selectedTab = tab

--- a/Sources/Coordinator/Extensions/Logger+Extensions.swift
+++ b/Sources/Coordinator/Extensions/Logger+Extensions.swift
@@ -1,0 +1,17 @@
+//
+//  Logger+Extensions.swift
+//  Coordinator
+//
+//  Created by Adam Kerenyi on 12.05.25.
+//
+
+import OSLog
+
+extension Logger {
+
+    /// Logger used by the **Coordinator** package.
+    static let coordinator = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "Coordinator",
+        category: "default"
+    )
+}

--- a/Sources/Coordinator/Routable.swift
+++ b/Sources/Coordinator/Routable.swift
@@ -8,7 +8,17 @@
 import SwiftUI
 
 /// A protocol defining a navigation route that can produce a SwiftUI `View`.
-public protocol Routable: View, Hashable, Identifiable {}
+public protocol Routable: View, Hashable, Identifiable, CustomStringConvertible {}
+
+// MARK: - CustomStringConvertible
+
+public extension Routable {
+
+    nonisolated var description: String {
+        let typeName = String(describing: Self.self)
+        return "\(typeName)(id: \"\(id)\")"
+    }
+}
 
 // - MARK: TabRoutable
 


### PR DESCRIPTION
Adds a Logger which can be access by importing `OSLog`.

Usage: 
```swift
Logger.coordinator.warning("Some warning.")

Logger.coordinator.info("Some info.")

...
```