### PR TITLE
Clean-up Coordination Protocols

### DIFF
--- a/Example/CoordinatorExample/Coordinators/HomeCoordinator.swift
+++ b/Example/CoordinatorExample/Coordinators/HomeCoordinator.swift
@@ -96,7 +96,7 @@ extension HomeCoordinator: DeepLinkHandling {
 
         switch firstRoute {
         case "view1":
-            popToRoot()
+            popToInitialRoute()
         case "view2":
             push(route: Screen.view2(coordinator: self))
         case "newFlowRoot":

--- a/Example/CoordinatorExample/Coordinators/NewFlowCoordinator.swift
+++ b/Example/CoordinatorExample/Coordinators/NewFlowCoordinator.swift
@@ -52,7 +52,7 @@ class NewFlowCoordinator: StackCoordinating, DeepLinkHandling, DeepLinkValidityC
             push(route: NewScreen.view2)
             return
         case "newFlowRoot":
-            popToRoot()
+            popToInitialRoute()
         default:
             throw DeepLinkingError.invalidDeepLink(firstRoute)
         }

--- a/Example/CoordinatorExample/Views/NewFlowRootView.swift
+++ b/Example/CoordinatorExample/Views/NewFlowRootView.swift
@@ -20,8 +20,8 @@ struct NewFlowRootView: View {
             Button("Pop") {
                 coordinator.pop()
             }
-            Button("Po to Root") {
-                coordinator.popToRoot()
+            Button("Pop to initial Route") {
+                coordinator.popToInitialRoute()
             }
         }
         .navigationTitle("NewFlow Root")

--- a/Example/CoordinatorExample/Views/View1.swift
+++ b/Example/CoordinatorExample/Views/View1.swift
@@ -37,8 +37,8 @@ struct NewFlowView1: View {
             Button("Pop") {
                 coordinator.pop()
             }
-            Button("Pop to Root") {
-                coordinator.popToRoot()
+            Button("Pop to initial Route") {
+                coordinator.popToInitialRoute()
 			}
         }
         .navigationTitle("View 1")

--- a/Example/CoordinatorExample/Views/View2.swift
+++ b/Example/CoordinatorExample/Views/View2.swift
@@ -18,8 +18,8 @@ struct View2: View {
             Button("Pop") {
                 coordinator.pop()
             }
-            Button("Pop to Root") {
-                coordinator.popToRoot()
+            Button("Pop to initial Route") {
+                coordinator.popToInitialRoute()
             }
             Button("New Flow") {
                 coordinator.push(coordinator: NewFlowCoordinator())

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ struct ContentView: View {
 To programmatically navigate to a new route, the coordinator offers several methods for the presentation of routes:
  - `push(_:)` - pushes a new route onto the `NavigationStack`
  - `pop()` - pops a route of the `NavigationStack`
- - `popToRoot()` - pops to the initial route of the coordinator
+ - `popToInitialRoute()` - pops to the initial route of the coordinator
  - `pushCoordinator(_:)` - pushes a new coordinator onto the `NavigationStack`
 
  ## Modal Coordinator

--- a/Sources/Coordinator/Coordinators/Coordinating.swift
+++ b/Sources/Coordinator/Coordinators/Coordinating.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Base protocol that defines the shared behavior and identity requirements for all coordinators.
 @MainActor
-public protocol Coordinating: ObservableObject, Identifiable, Hashable, Equatable, CustomStringConvertible {
+public protocol Coordinating: ObservableObject, Identifiable, Hashable, CustomStringConvertible {
 
     /// The unique identifier of the coordinator.
     nonisolated var id: String { get }

--- a/Sources/Coordinator/Coordinators/Coordinating.swift
+++ b/Sources/Coordinator/Coordinators/Coordinating.swift
@@ -13,7 +13,6 @@ public protocol Coordinating: ObservableObject, Identifiable, Hashable, CustomSt
 
     /// The unique identifier of the coordinator.
     nonisolated var id: String { get }
-
 }
 
 // MARK: - Hashable

--- a/Sources/Coordinator/Coordinators/Modal/ModalCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Modal/ModalCoordinating.swift
@@ -11,8 +11,8 @@ import OSLog
 /// A protocol defining the requirements for coordinators that manage the presentation of modals.
 ///
 /// This protocol enables the presentation of modals like `.fullScreenCover`s & `.sheet`s.
-@MainActor
 public protocol ModalCoordinating: Coordinating {
+    
     /// The type representing a modal route.
     associatedtype Route: Routable
     
@@ -23,29 +23,15 @@ public protocol ModalCoordinating: Coordinating {
     
     /// The route which is currently presented as a full screen cover, if any.
     var fullScreenCover: Route? { get set }
-    
-    // MARK: - Methods
-
-    /// Presents a new `Route` with the given `ModalPresentationStyle`.
-    /// - Parameters:
-    ///   - route: The `Route` to present modally.
-    ///   - presentationStyle: The `ModalPresentationStyle` to present the route with.
-    func present(
-        _ route: Route,
-        as presentationStyle: ModalPresentationStyle
-    )
-    
-    /// Dismisses the `View` currently presented using the given `PresentationStyle`.
-    func dismiss(_ presentationStyle: ModalPresentationStyle)
 }
 
-// MARK: - Default Implementations
+// MARK: - Navigation Methods
 
 public extension ModalCoordinating {
     
-    /// Default implementation of `present(_:)`, presenting a route modally with the given `ModalPresentationStyle`.
+    /// Presents a new `Route` with the given `ModalPresentationStyle`.
     /// - Parameters:
-    ///   - route: The `Routable` instance to present.
+    ///   - route: The `Route` to present modally.
     ///   - presentationStyle: The `ModalPresentationStyle` to present the route with.
     func present(
         _ route: Route,
@@ -67,8 +53,8 @@ public extension ModalCoordinating {
         }
     }
     
-    /// Default implementation of `dismiss(_:)`, dismissing the current route with the given `ModalPresentationStyle`.
-    /// - Parameter presentationStyle: The `View` with the `ModalPresentationStyle` to dismiss.
+    /// Dismisses the currently presented modal `Route` with the specified `ModalPresentationStyle`.
+    /// - Parameter presentationStyle: The presentation style to dismiss
     func dismiss(_ presentationStyle: ModalPresentationStyle) {
         switch presentationStyle {
         case .sheet:

--- a/Sources/Coordinator/Coordinators/Modal/ModalPresentationStyle.swift
+++ b/Sources/Coordinator/Coordinators/Modal/ModalPresentationStyle.swift
@@ -8,7 +8,7 @@
 /// An enumeration that defines the available presentation styles for modals.
 public enum ModalPresentationStyle {
     
-    /// Presents the `View` modally over the current context.
+    /// Presents a `View` modally as a sheet over the current context.
     case sheet
     
     /// Presents a full screen `View`, which covers as much of the screen as possible.

--- a/Sources/Coordinator/Coordinators/Stack/RootStackCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/RootStackCoordinating.swift
@@ -8,34 +8,17 @@
 import SwiftUI
 import OSLog
 
-public protocol RootStackCoordinating: StackCoordinating {
+/// A protocol that defines an object responsible of managing the underlying `NavigationPath` in any stack-based navigation.
+@MainActor
+public protocol RootStackCoordinating: ObservableObject, CustomStringConvertible {
 
+    /// The SwiftUI `NavigationPath` representing current navigation state.
     var path: NavigationPath { get set }
-
-    /// Pushes a new `Route` onto the `NavigationStack`.
-    ///
-    /// > The `Route` type is not bound to any coordinator's associated type. Thus, `any Routable`can be pushed.
-    ///
-    /// - Parameter route: The `Route` to push.
-    func push<Route: Routable>(_ route: Route)
 }
 
-// MARK: - Default Implementations
+// MARK: - Navigation Methods
 
 public extension RootStackCoordinating {
-    
-    // MARK: - Properties
-    
-    /// The `root` is always `nil` for root stack coordinators.
-    var root: (any RootStackCoordinating)? {
-        get { nil }
-        set { }
-    }
-
-    var presentedRoutes: [Route] {
-        get { [] }
-        set { }
-    }
 
     // MARK: - Methods
 
@@ -51,13 +34,14 @@ public extension RootStackCoordinating {
         path.append(route)
     }
     
-    /// Pops the top-most view from the navigation stack.
+    /// Pops the top-most route from the navigation stack.
     func pop() {
         popLast(1)
     }
     
     /// Pops all views from the navigation stack except the root view.
-    /// - This resets the navigation state back to the initial route.
+    ///
+    /// This resets the navigation state back to the initial route.
     func popToRoot() {
         path = NavigationPath()
     }
@@ -73,14 +57,24 @@ public extension RootStackCoordinating {
     }
 }
 
+
+// MARK: - CustomStringConvertible
+
+public extension RootStackCoordinating {
+    
+    nonisolated var description: String {
+        let typeName = String(describing: Self.self)
+        let objectID = ObjectIdentifier(self)
+        return "\(typeName)(objectID: \"\(objectID)\")"
+    }
+}
+
 // MARK: - RootStackCoordinator
 
+/// A concrete implementation of `RootStackCoordinating` that manages the `NavigationPath` and initial route.
 public final class RootStackCoordinator<Route: Routable>: RootStackCoordinating {
 
 	// MARK: - Public Properties
-    
-    /// The unique identifier of the coordinator.
-    public nonisolated let id: String
 
 	/// The navigation path representing the current state of navigation.
 	@Published public var path = NavigationPath()
@@ -90,10 +84,9 @@ public final class RootStackCoordinator<Route: Routable>: RootStackCoordinating 
 
 	// MARK: - Initialization
 
-	/// Initializes a new `RootCoordinator` with a given `Coordinator`.
-	/// - Parameter coordinator: The initial `Coordinator` that this root coordinator manages.
+	/// Initializes a new `RootStackCoordinator` with the  given coordinator.
+	/// - Parameter coordinator: A initial stack-based coordinator.
 	public init<C: StackCoordinating>(coordinator: C) where C.Route == Route {
-        self.id = "RootStackCoordinator<\(coordinator)>"
 		self.initialRoute = coordinator.initialRoute
         self.path = NavigationPath(coordinator.presentedRoutes)
 		coordinator.root = self

--- a/Sources/Coordinator/Coordinators/Stack/RootStackCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/RootStackCoordinating.swift
@@ -39,9 +39,9 @@ public extension RootStackCoordinating {
         popLast(1)
     }
     
-    /// Pops all views from the navigation stack except the root view.
+    /// Pops all views from the `NavigationStack` - leaving only the initial route.
     ///
-    /// This resets the navigation state back to the initial route.
+    /// This effectively empties the `NavigationPath`.
     func popToRoot() {
         path = NavigationPath()
     }

--- a/Sources/Coordinator/Coordinators/TabView/TabViewCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/TabView/TabViewCoordinating.swift
@@ -13,33 +13,31 @@ import OSLog
 /// Conforming types are responsible for managing a set of tabs and handling tab selection.
 @MainActor
 public protocol TabViewCoordinating: Coordinating {
+
     /// The type representing a tab route.
     associatedtype Route: TabRoutable
     
     // MARK: - Properties
 
     /// The currently selected tab.
+    ///
+    /// This property reflects the active tab in the `TabView`, and updates when the user switches tabs.
     var selectedTab: Route { get set }
     
     /// The list of displayed tabs.
     var tabs: [Route] { get }
-    
-    // MARK: - Methods
-    
-    /// Selects the specified tab.
-    /// - Parameter tab: The tab to be selected.
-    func select(_ tab: Route)
 }
 
-// MARK: - Default Implementation
+// MARK: - Navigation Methods
 
 public extension TabViewCoordinating {
     
-    /// Default implementation of the `select(_:)` method, selecting the given `tab`.
+    /// Selects the specified tab.
     ///
-    /// Attempts to select a tab. If the tab is not part of the registered `tabs`,
-    /// a warning is printed and no selection is made.
-    /// - Parameter tab: The tab to select.
+    /// This method updates `selectedTab` if the provided tab is part of the `tabs` collection.
+    /// If the tab is not registered, a warning is logged and the selection is ignored.
+    ///
+    /// - Parameter tab: The tab `Route` to select.
     func select(_ tab: Route) {
         guard tabs.contains(tab) else {
             Logger.coordinator.warning("Cannot select tab from \"\(self)\": \"\(tab)\" is unregistered.")

--- a/Sources/Coordinator/Routable.swift
+++ b/Sources/Coordinator/Routable.swift
@@ -24,6 +24,7 @@ public extension Routable {
 
 /// A protocol defining a navigation route for a `TabView` which can produce a SwiftUI `View`.
 public protocol TabRoutable: Routable {
+    
     /// The label to use for the `Tab`.
     var label: Label<Text, Image> { get }
 }

--- a/Tests/CoordinatorTests/StackCoordinatingTests.swift
+++ b/Tests/CoordinatorTests/StackCoordinatingTests.swift
@@ -15,7 +15,7 @@ import SwiftUI
 
     // - MARK: Initialization Tests
     
-    @Test func testInit() {
+    @Test func testInit() throws {
         // GIVEN: An initialized coordinator (SUT).
         let sut = MockStackCoordinator()
         
@@ -24,11 +24,11 @@ import SwiftUI
         
         // THEN: The SUT's root is set.
         #expect(sut.root != nil, "Root is expected to be non-nil")
-        #expect(sut.root is RootStackCoordinator<MockRoute>, "Root is expected to have type RootStackCoordinator")
-        #expect(sut.root?.initialRoute.hashValue == root.initialRoute.hashValue, "Initial routes are expected to match")
+        let sutRoot = try #require(sut.root as? RootStackCoordinator<MockRoute>, "Root is expected to have type RootStackCoordinator")
+        #expect(sutRoot.initialRoute == root.initialRoute, "Initial routes are expected to match")
     }
     
-    @Test func testInitPath() {
+    @Test func testInitPath() throws {
         // GIVEN: An initialized coordinator (SUT) with an initial path.
         let presentedRoutes = [MockRoute.route1, MockRoute.route2]
         let sut = MockStackCoordinator(presentedRoutes: presentedRoutes)
@@ -37,8 +37,9 @@ import SwiftUI
         let root = RootStackCoordinator(coordinator: sut)
         
         // THEN: The root coordinator's path matches the SUT's path.
+        let sutRoot = try #require(sut.root as? RootStackCoordinator<MockRoute>, "Root is expected to have type RootStackCoordinator")
         #expect(sut.presentedRoutes.count == root.path.count, "SUT and root presentedRoutes's are expected to be equal")
-        #expect(sut.root?.initialRoute.hashValue == root.initialRoute.hashValue, "Initial routes are expected to match")
+        #expect(sutRoot.initialRoute == root.initialRoute, "Initial routes are expected to match")
     }
     
     // - MARK: Push Coordinator Tests

--- a/Tests/CoordinatorTests/StackCoordinatingTests.swift
+++ b/Tests/CoordinatorTests/StackCoordinatingTests.swift
@@ -148,16 +148,16 @@ import SwiftUI
         #expect(sut.presentedRoutes == presentedRoutes, "The SUT's presentedRoutes is expected to equal the initial presentedRoutes")
     }
     
-    // - MARK: PopToRoot Tests
+    // - MARK: PopToInitialRoute Tests
     
-    @Test func testPopToRootSuccessNonEmptyPath() {
+    @Test func testPopToInitialRouteSuccessNonEmptyPath() {
         // GIVEN: An initialized coordinator (SUT) & root coordinator with an initial path.
         let presentedRoutes = [MockRoute.route1, MockRoute.route2]
         let sut = MockStackCoordinator(presentedRoutes: presentedRoutes)
         let root = RootStackCoordinator(coordinator: sut)
         
-        // WHEN: The SUT pop to root.
-        sut.popToRoot()
+        // WHEN: The SUT pop to initial route.
+        sut.popToInitialRoute()
         
         // THEN: The SUT's path is expected not to change.
         #expect(sut.presentedRoutes.isEmpty, "The SUT's presentedRoutes is expected to be empty")
@@ -166,13 +166,13 @@ import SwiftUI
         #expect(sut.presentedRoutes.count == root.path.count, "The SUT presentedRoutes and root path are expected to be equal")
     }
     
-    @Test func testPopToRootSuccessEmptyPath() {
+    @Test func testPopToInitialRouteSuccessEmptyPath() {
         // GIVEN: An initialized coordinator (SUT) & root coordinator without an initial path.
         let sut = MockStackCoordinator()
         let root = RootStackCoordinator(coordinator: sut)
         
-        // WHEN: The SUT pop to root.
-        sut.popToRoot()
+        // WHEN: The SUT pop to initial route.
+        sut.popToInitialRoute()
         
         // THEN: The SUT's path is expected not to change.
         #expect(sut.presentedRoutes.isEmpty, "The SUT's presentedRoutes is expected to be empty")
@@ -181,13 +181,13 @@ import SwiftUI
         #expect(sut.presentedRoutes.count == root.path.count, "The SUT presentedRoutes and root path are expected to be equal")
     }
     
-    @Test func testPopToRootError() {
+    @Test func testPopToInitialRouteError() {
         // GIVEN: An initialized coordinator (SUT) with an initial path.
         let presentedRoutes = [MockRoute.route1, MockRoute.route2]
         let sut = MockStackCoordinator(presentedRoutes: presentedRoutes)
         
         // WHEN: The SUT pop to root.
-        sut.popToRoot()
+        sut.popToInitialRoute()
         
         // THEN: The SUT's path is expected equal the initial path.
         #expect(sut.presentedRoutes == presentedRoutes, "The SUT's presentedRoutes is expected to equal the initial presentedRoutes")


### PR DESCRIPTION
This pull request refactors navigation and coordinator protocols to improve clarity, consistency, and documentation across the codebase. The most significant change is the introduction of a clear distinction between popping to the initial route of a coordinator (`popToInitialRoute`) and popping to the root of the navigation stack (`popToRoot`). Additionally, protocol documentation and method naming have been standardized, and some protocol requirements have been adjusted for better usability.


These changes make navigation logic clearer, improve code maintainability, and help prevent confusion when managing complex coordinator hierarchies.