### PR TITLE
Fix Path-Inconsistency

### DIFF
--- a/Example/CoordinatorExample/Coordinators/HomeCoordinator.swift
+++ b/Example/CoordinatorExample/Coordinators/HomeCoordinator.swift
@@ -16,9 +16,7 @@ class HomeCoordinator: StackCoordinating, ModalCoordinating {
 
     var initialRoute: Screen { Screen.view1(coordinator: self) }
 
-    var presentedRoutes = [Screen]()
-
-    weak var root: (any RootStackCoordinating)?
+    weak var root: (any StackNavigating)?
 
     @Published var sheet: Screen?
 

--- a/Example/CoordinatorExample/Coordinators/NewFlowCoordinator.swift
+++ b/Example/CoordinatorExample/Coordinators/NewFlowCoordinator.swift
@@ -15,10 +15,8 @@ class NewFlowCoordinator: StackCoordinating, DeepLinkHandling, DeepLinkValidityC
     let id = "NewFlowCoordinator"
 
     var initialRoute: NewScreen { NewScreen.newFlowRoot(coordinator: self) }
-    
-    var presentedRoutes = [NewScreen]()
-    
-    weak var root: (any RootStackCoordinating)?
+        
+    weak var root: (any StackNavigating)?
     
     // - MARK: Initialization
 

--- a/Sources/Coordinator/Coordinators/Stack/NavigationPathManager.swift
+++ b/Sources/Coordinator/Coordinators/Stack/NavigationPathManager.swift
@@ -1,5 +1,5 @@
 //
-//  RootStackCoordinating.swift
+//  NavigationPathManager.swift
 //  Coordinator
 //
 //  Created by Joseph Grabinger on 25.03.25.
@@ -8,13 +8,13 @@
 import SwiftUI
 import OSLog
 
-/// A concrete implementation of `RootStackCoordinating` that manages the `NavigationPath` and initial route.
-public final class RootStackCoordinator<R: Routable>: StackNavigating {
+/// A concrete implementation of `StackNavigating` that manages the `NavigationPath` in a `NavigationStack`.
+public final class NavigationPathManager<R: Routable>: StackNavigating {
     
-    // MARK: - Public Properties
+    // MARK: - Internal Properties
     
     /// The navigation path representing the current state of navigation.
-    @Published public var path = NavigationPath() {
+    @Published var path = NavigationPath() {
         didSet {
             guard path.count < oldValue.count else { return }
             transitionIndices = transitionIndices.filter { _, index in
@@ -30,11 +30,11 @@ public final class RootStackCoordinator<R: Routable>: StackNavigating {
     private(set) var transitionIndices = [String: Int]()
     
     /// The initial route that this coordinator starts with.
-    public let initialRoute: R
+    let initialRoute: R
     
     // MARK: - Initialization
     
-    /// Initializes a new `RootStackCoordinator` with the  given coordinator.
+    /// Initializes a new `NavigationPathManager` with the  given coordinator.
     /// - Parameter coordinator: A initial stack-based coordinator.
     public init<C: StackCoordinating>(coordinator: C) where C.Route == R {
         self.initialRoute = coordinator.initialRoute
@@ -44,7 +44,7 @@ public final class RootStackCoordinator<R: Routable>: StackNavigating {
 
 // MARK: StackNavigating
 
-public extension RootStackCoordinator {
+public extension NavigationPathManager {
     
     func pushCoordinator(_ coordinator: any StackCoordinating) {
         coordinator.root = self

--- a/Sources/Coordinator/Coordinators/Stack/NavigationPathManager.swift
+++ b/Sources/Coordinator/Coordinators/Stack/NavigationPathManager.swift
@@ -69,7 +69,7 @@ public extension NavigationPathManager {
             Logger.coordinator.warning("\(self) cannot pop coordinator \(coordinator.description): no transition index found.")
             return
         }
-        let routesToPop = path.count - transitionIndex - 1
+        let routesToPop = path.count - transitionIndex
         popRoute(count: routesToPop)
     }
     
@@ -78,7 +78,7 @@ public extension NavigationPathManager {
             Logger.coordinator.warning("\(self) cannot pop to initial route of \(coordinator.description): no transition index found.")
             return
         }
-        let routesToPop = path.count - transitionIndex
+        let routesToPop = path.count - transitionIndex - 1
         popRoute(count: routesToPop)
     }
     

--- a/Sources/Coordinator/Coordinators/Stack/RootStackCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/RootStackCoordinating.swift
@@ -10,50 +10,53 @@ import OSLog
 
 /// A concrete implementation of `RootStackCoordinating` that manages the `NavigationPath` and initial route.
 public final class RootStackCoordinator<R: Routable>: StackNavigating {
-
-	// MARK: - Public Properties
-
-	/// The navigation path representing the current state of navigation.
+    
+    // MARK: - Public Properties
+    
+    /// The navigation path representing the current state of navigation.
     @Published public var path = NavigationPath() {
         didSet {
             guard path.count < oldValue.count else { return }
-            transitionPoints = transitionPoints.filter { _, index in
+            transitionIndices = transitionIndices.filter { _, index in
                 return index <= path.count - 1
             }
         }
     }
     
-    /// A dictionary holding the transition points of the pushed coordinators.
+    /// A dictionary holding the transition indices of the pushed coordinators.
     ///
     /// The key is the `StackCoordinating`-conforming coordinator's ID.
-    /// And the value corresponds to the index  coordinator's `initialRoute` within the `path`.
-    private(set) var transitionPoints = [String: Int]()
-
-	/// The initial route that this coordinator starts with.
+    /// And the value corresponds to the index of the coordinator's `initialRoute` within the `path`.
+    private(set) var transitionIndices = [String: Int]()
+    
+    /// The initial route that this coordinator starts with.
     public let initialRoute: R
-
-	// MARK: - Initialization
-
-	/// Initializes a new `RootStackCoordinator` with the  given coordinator.
-	/// - Parameter coordinator: A initial stack-based coordinator.
-	public init<C: StackCoordinating>(coordinator: C) where C.Route == R {
-		self.initialRoute = coordinator.initialRoute
-		coordinator.root = self
-	}
     
-    // MARK: Public Methods
+    // MARK: - Initialization
     
-    public func pushCoordinator(_ coordinator: any StackCoordinating) {
+    /// Initializes a new `RootStackCoordinator` with the  given coordinator.
+    /// - Parameter coordinator: A initial stack-based coordinator.
+    public init<C: StackCoordinating>(coordinator: C) where C.Route == R {
+        self.initialRoute = coordinator.initialRoute
         coordinator.root = self
-        transitionPoints[coordinator.id] = path.count
+    }
+}
+
+// MARK: StackNavigating
+
+public extension RootStackCoordinator {
+    
+    func pushCoordinator(_ coordinator: any StackCoordinating) {
+        coordinator.root = self
+        transitionIndices[coordinator.id] = path.count
         pushRoute(coordinator.initialRoute)
     }
     
-    public func pushRoute<Route: Routable>(_ route: Route) where Route : Routable {
+    func pushRoute<Route: Routable>(_ route: Route) where Route : Routable {
         path.append(route)
     }
     
-    public func popRoute(count: Int) {
+    func popRoute(count: Int) {
         guard path.count >= count else {
             Logger.coordinator.warning("\(self) cannot pop \(count) routes: path contains only \(self.path.count).")
             return
@@ -61,8 +64,26 @@ public final class RootStackCoordinator<R: Routable>: StackNavigating {
         path.removeLast(count)
     }
     
-    public func popToRoot() {
+    func popCoordinator(_ coordinator: any StackCoordinating) {
+        guard let transitionIndex = transitionIndices[coordinator.id] else {
+            Logger.coordinator.warning("\(self) cannot pop coordinator \(coordinator.description): no transition index found.")
+            return
+        }
+        let routesToPop = path.count - transitionIndex - 1
+        popRoute(count: routesToPop)
+    }
+    
+    func popToInitialRoute(of coordinator: any StackCoordinating) {
+        guard let transitionIndex = transitionIndices[coordinator.id] else {
+            Logger.coordinator.warning("\(self) cannot pop to initial route of \(coordinator.description): no transition index found.")
+            return
+        }
+        let routesToPop = path.count - transitionIndex
+        popRoute(count: routesToPop)
+    }
+    
+    func popToRoot() {
         path = NavigationPath()
-        transitionPoints = [:]
+        transitionIndices = [:]
     }
 }

--- a/Sources/Coordinator/Coordinators/Stack/RootStackCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/RootStackCoordinating.swift
@@ -14,7 +14,20 @@ public final class RootStackCoordinator<R: Routable>: StackNavigating {
 	// MARK: - Public Properties
 
 	/// The navigation path representing the current state of navigation.
-	@Published public var path = NavigationPath()
+    @Published public var path = NavigationPath() {
+        didSet {
+            guard path.count < oldValue.count else { return }
+            transitionPoints = transitionPoints.filter { _, index in
+                return index <= path.count - 1
+            }
+        }
+    }
+    
+    /// A dictionary holding the transition points of the pushed coordinators.
+    ///
+    /// The key is the `StackCoordinating`-conforming coordinator's ID.
+    /// And the value corresponds to the index  coordinator's `initialRoute` within the `path`.
+    private(set) var transitionPoints = [String: Int]()
 
 	/// The initial route that this coordinator starts with.
     public let initialRoute: R
@@ -32,6 +45,7 @@ public final class RootStackCoordinator<R: Routable>: StackNavigating {
     
     public func pushCoordinator(_ coordinator: any StackCoordinating) {
         coordinator.root = self
+        transitionPoints[coordinator.id] = path.count
         pushRoute(coordinator.initialRoute)
     }
     
@@ -49,5 +63,6 @@ public final class RootStackCoordinator<R: Routable>: StackNavigating {
     
     public func popToRoot() {
         path = NavigationPath()
+        transitionPoints = [:]
     }
 }

--- a/Sources/Coordinator/Coordinators/Stack/RootStackCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/RootStackCoordinating.swift
@@ -25,7 +25,6 @@ public final class RootStackCoordinator<R: Routable>: StackNavigating {
 	/// - Parameter coordinator: A initial stack-based coordinator.
 	public init<C: StackCoordinating>(coordinator: C) where C.Route == R {
 		self.initialRoute = coordinator.initialRoute
-        self.path = NavigationPath(coordinator.presentedRoutes)
 		coordinator.root = self
 	}
     

--- a/Sources/Coordinator/Coordinators/Stack/StackCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/StackCoordinating.swift
@@ -62,21 +62,22 @@ public extension StackCoordinating {
     }
 
     /// Pops all of the current coordinator's routes from the `NavigationStack` and returns to the initial route of the coordinator.
-//    func popToInitialRoute() {
-//        guard let root else {
-//            Logger.coordinator.warning("Cannot pop to initial route from \"\(self)\": root is nil.")
-//            return
-//        }
-//        root.popRoute(count: presentedRoutes.count)
-//    }
+    func popToInitialRoute() {
+        guard let root else {
+            Logger.coordinator.warning("Cannot pop to initial route from \"\(self)\": root is nil.")
+            return
+        }
+        root.popToInitialRoute(of: self)
+    }
 
     /// Pops all routes from the `NavigationStack` and returns to the previous coordinator.
-//    func popToPrevious() {
-//        guard let root else {
-//            Logger.coordinator.warning("Cannot pop to previous coordinator from \"\(self)\": root is nil.")
-//            return
-//        }
-//    }
+    func popToPreviousCoordinator() {
+        guard let root else {
+            Logger.coordinator.warning("Cannot pop to previous coordinator from \"\(self)\": root is nil.")
+            return
+        }
+        root.popCoordinator(self)
+    }
 
     /// Pops all routes and returns to the root of the `NavigationStack`.
     func popToRoot() {

--- a/Sources/Coordinator/Coordinators/Stack/StackCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/StackCoordinating.swift
@@ -26,10 +26,6 @@ public protocol StackCoordinating: Coordinating {
     /// A weak reference to the root coordinator, if available.
     /// - Important: This reference must be weak to avoid retain cycles.
     var root: (any StackNavigating)? { get set }
-
-    /// The navigation path representing the current state of navigation.
-    /// - Warning: Do not mutate this directly. Use navigation methods instead.
-    var presentedRoutes: [Route] { get set }
 }
 
 // MARK: - Navigation Methods
@@ -54,7 +50,6 @@ public extension StackCoordinating {
             return
         }
         root.pushRoute(route)
-        presentedRoutes.append(route)
     }
 
     /// Pops the top-most route from the `NavigationStack`.
@@ -64,29 +59,24 @@ public extension StackCoordinating {
             return
         }
         root.popRoute()
-        guard presentedRoutes.count >= 1 else { return }
-        presentedRoutes.removeLast()
     }
 
     /// Pops all of the current coordinator's routes from the `NavigationStack` and returns to the initial route of the coordinator.
-    func popToInitialRoute() {
-        guard let root else {
-            Logger.coordinator.warning("Cannot pop to initial route from \"\(self)\": root is nil.")
-            return
-        }
-        root.popRoute(count: presentedRoutes.count)
-        presentedRoutes = []
-    }
+//    func popToInitialRoute() {
+//        guard let root else {
+//            Logger.coordinator.warning("Cannot pop to initial route from \"\(self)\": root is nil.")
+//            return
+//        }
+//        root.popRoute(count: presentedRoutes.count)
+//    }
 
     /// Pops all routes from the `NavigationStack` and returns to the previous coordinator.
-    func popToPrevious() {
-        guard let root else {
-            Logger.coordinator.warning("Cannot pop to previous coordinator from \"\(self)\": root is nil.")
-            return
-        }
-        root.popRoute(count: presentedRoutes.count + 1)
-        presentedRoutes = []
-    }
+//    func popToPrevious() {
+//        guard let root else {
+//            Logger.coordinator.warning("Cannot pop to previous coordinator from \"\(self)\": root is nil.")
+//            return
+//        }
+//    }
 
     /// Pops all routes and returns to the root of the `NavigationStack`.
     func popToRoot() {

--- a/Sources/Coordinator/Coordinators/Stack/StackCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/StackCoordinating.swift
@@ -13,7 +13,6 @@ import OSLog
 /// This protocol enables hierarchical navigation using coordinators and routes.
 ///
 /// - Warning: Do not set the properties manually.
-@MainActor
 public protocol StackCoordinating: Coordinating {
     
     /// The type representing a route.

--- a/Sources/Coordinator/Coordinators/Stack/StackCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/StackCoordinating.swift
@@ -25,7 +25,7 @@ public protocol StackCoordinating: Coordinating {
 
     /// A weak reference to the root coordinator, if available.
     /// - Important: This reference must be weak to avoid retain cycles.
-    var root: (any RootStackCoordinating)? { get set }
+    var root: (any StackNavigating)? { get set }
 
     /// The navigation path representing the current state of navigation.
     /// - Warning: Do not mutate this directly. Use navigation methods instead.
@@ -43,8 +43,7 @@ public extension StackCoordinating {
             Logger.coordinator.warning("Cannot push \"\(coordinator.description)\" from \"\(self)\": root is nil.")
             return
         }
-        coordinator.root = root
-        root.push(coordinator: coordinator)
+        root.pushCoordinator(coordinator)
     }
 
     /// Pushes a new route onto the `NavigationStack`.
@@ -54,7 +53,7 @@ public extension StackCoordinating {
             Logger.coordinator.warning("Cannot push \"\(route)\" from \"\(self)\": root is nil.")
             return
         }
-        root.push(route)
+        root.pushRoute(route)
         presentedRoutes.append(route)
     }
 
@@ -64,7 +63,7 @@ public extension StackCoordinating {
             Logger.coordinator.warning("Cannot pop from \"\(self)\": root is nil.")
             return
         }
-        root.pop()
+        root.popRoute()
         guard presentedRoutes.count >= 1 else { return }
         presentedRoutes.removeLast()
     }
@@ -75,7 +74,7 @@ public extension StackCoordinating {
             Logger.coordinator.warning("Cannot pop to initial route from \"\(self)\": root is nil.")
             return
         }
-        root.popLast(presentedRoutes.count)
+        root.popRoute(count: presentedRoutes.count)
         presentedRoutes = []
     }
 
@@ -85,11 +84,7 @@ public extension StackCoordinating {
             Logger.coordinator.warning("Cannot pop to previous coordinator from \"\(self)\": root is nil.")
             return
         }
-        guard root.path.count > presentedRoutes.count else {
-            Logger.coordinator.warning("Cannot pop to previous coordinator from \"\(self)\": routes inconsistent with root path.")
-            return
-        }
-        root.popLast(presentedRoutes.count + 1)
+        root.popRoute(count: presentedRoutes.count + 1)
         presentedRoutes = []
     }
 

--- a/Sources/Coordinator/Coordinators/Stack/StackNavigating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/StackNavigating.swift
@@ -14,16 +14,27 @@ public protocol StackNavigating: ObservableObject, CustomStringConvertible {
     // MARK: Methods
     
     /// Pushes a new coordinator onto the navigation stack.
-    /// - Parameter coordinator: A `StackCoordinating`-conforming instance to push.
+    /// - Parameter coordinator: The `StackCoordinating`-conforming instance to push.
     func pushCoordinator(_ coordinator: any StackCoordinating)
     
     /// Pushes a new `Route` onto the navigation stack.
-    /// - Parameter route: A `Routable`-conforming route to push.
+    /// - Parameter route: The `Routable`-conforming route to push.
     func pushRoute<Route: Routable>(_ route: Route)
     
     /// Pops the specified number of routes of the navigation stack.
     /// - Parameter count: The number of routes to pop.
     func popRoute(count: Int)
+    
+    /// Pops the current coordinator of the navigation stack.
+    /// 
+    /// This effectively displays the lat route before the given coordinator.
+    ///
+    /// - Parameter coordinator: The `StackCoordinating`-conforming instance to pop.
+    func popCoordinator(_ coordinator: any StackCoordinating)
+    
+    /// Pops all routes until the initial route of the given coordinator of the navigation stack.
+    /// - Parameter coordinator: The `StackCoordinating`-conforming instance to whose initial route to pop.
+    func popToInitialRoute(of coordinator: any StackCoordinating)
     
     /// Pops all routes of the navigation stack.
     ///

--- a/Sources/Coordinator/Coordinators/Stack/StackNavigating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/StackNavigating.swift
@@ -5,9 +5,11 @@
 //  Created by Joseph Grabinger on 10.08.25.
 //
 
+import Foundation
+
 /// A protocol that defines methods for stack-based navigation.
 @MainActor
-public protocol StackNavigating {
+public protocol StackNavigating: ObservableObject, CustomStringConvertible {
     
     // MARK: Methods
     
@@ -36,5 +38,16 @@ public extension StackNavigating {
     /// Pops the top-most route of the navigation stack.
     func popRoute() {
         self.popRoute(count: 1)
+    }
+}
+
+// MARK: CustomStringConvertible
+
+public extension StackNavigating {
+
+    nonisolated var description: String {
+        let typeName = String(describing: Self.self)
+        let objectID = ObjectIdentifier(self)
+        return "\(typeName)(objectID: \"\(objectID)\")"
     }
 }

--- a/Sources/Coordinator/Coordinators/Stack/StackNavigating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/StackNavigating.swift
@@ -27,7 +27,7 @@ public protocol StackNavigating: ObservableObject, CustomStringConvertible {
     
     /// Pops the current coordinator of the navigation stack.
     /// 
-    /// This effectively displays the lat route before the given coordinator.
+    /// This effectively displays the last route before the given coordinator.
     ///
     /// - Parameter coordinator: The `StackCoordinating`-conforming instance to pop.
     func popCoordinator(_ coordinator: any StackCoordinating)

--- a/Sources/Coordinator/Coordinators/Stack/StackNavigating.swift
+++ b/Sources/Coordinator/Coordinators/Stack/StackNavigating.swift
@@ -1,0 +1,40 @@
+//
+//  StackNavigating.swift
+//  Coordinator
+//
+//  Created by Joseph Grabinger on 10.08.25.
+//
+
+/// A protocol that defines methods for stack-based navigation.
+@MainActor
+public protocol StackNavigating {
+    
+    // MARK: Methods
+    
+    /// Pushes a new coordinator onto the navigation stack.
+    /// - Parameter coordinator: A `StackCoordinating`-conforming instance to push.
+    func pushCoordinator(_ coordinator: any StackCoordinating)
+    
+    /// Pushes a new `Route` onto the navigation stack.
+    /// - Parameter route: A `Routable`-conforming route to push.
+    func pushRoute<Route: Routable>(_ route: Route)
+    
+    /// Pops the specified number of routes of the navigation stack.
+    /// - Parameter count: The number of routes to pop.
+    func popRoute(count: Int)
+    
+    /// Pops all routes of the navigation stack.
+    ///
+    /// This effectively resets the stack to its initial route.
+    func popToRoot()
+}
+
+// MARK: - Convenience Methods
+
+public extension StackNavigating {
+    
+    /// Pops the top-most route of the navigation stack.
+    func popRoute() {
+        self.popRoute(count: 1)
+    }
+}

--- a/Sources/Coordinator/Coordinators/TabView/TabViewCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/TabView/TabViewCoordinating.swift
@@ -11,7 +11,6 @@ import OSLog
 /// A protocol that defines the coordination logic for a tab-based navigation system.
 ///
 /// Conforming types are responsible for managing a set of tabs and handling tab selection.
-@MainActor
 public protocol TabViewCoordinating: Coordinating {
 
     /// The type representing a tab route.

--- a/Sources/Coordinator/Views/CoordinatedStack.swift
+++ b/Sources/Coordinator/Views/CoordinatedStack.swift
@@ -7,14 +7,13 @@
 
 import SwiftUI
 
-/// A SwiftUI view that serves as the root coordinator, managing navigation within the app.
-/// - Note: This `View` integrates with a `StackCoordinating`-conforming coordinator to handle navigation.
+/// A SwiftUI view that creates a `NavigationStack` driven by a `StackCoordinating`-conforming coordinator.
 public struct CoordinatedStack<Coordinator: StackCoordinating>: View {
 
     // MARK: - Private Properties
     
-    /// The root coordinator responsible for managing the `NavigationPath` that's bound to the `NavigationStack`.
-    @StateObject private var rootCoordinator: RootStackCoordinator<Coordinator.Route>
+    /// The object responsible for managing the `NavigationPath` that's bound to the `NavigationStack`.
+    @StateObject private var pathManager: NavigationPathManager<Coordinator.Route>
     
     // MARK: - Initialization
 
@@ -22,14 +21,14 @@ public struct CoordinatedStack<Coordinator: StackCoordinating>: View {
     /// - Parameters:
     ///   - coordinator: The coordinator responsible for managing navigation.
     public init(for coordinator: Coordinator) {
-		_rootCoordinator = StateObject(wrappedValue: RootStackCoordinator(coordinator: coordinator))
+		_pathManager = StateObject(wrappedValue: NavigationPathManager(coordinator: coordinator))
     }
     
     // MARK: - Body
 
     public var body: some View {
-        NavigationStack(path: $rootCoordinator.path) {
-			rootCoordinator.initialRoute
+        NavigationStack(path: $pathManager.path) {
+			pathManager.initialRoute
                 .navigationDestination(for: Coordinator.Route.self) { $0 }
         }
     }

--- a/Tests/CoordinatorTests/StackCoordinatingTests.swift
+++ b/Tests/CoordinatorTests/StackCoordinatingTests.swift
@@ -117,7 +117,7 @@ import SwiftUI
     }
     
     @Test func popRouteErrorNilRoot() {
-        // GIVEN: An initialized coordinator (SUT)whose root is nil.
+        // GIVEN: An initialized coordinator (SUT) whose root is nil.
         let sut = MockStackCoordinator()
         
         // WHEN: A route is popped.
@@ -224,12 +224,13 @@ import SwiftUI
         // AND: Routes are pushed.
         sut.push(route: .route2)
         sut.push(route: .route3)
+        #expect(root.path.count == 2)
         
         // WHEN: The SUT pop to initial route.
         sut.popToInitialRoute()
         
         // THEN: The SUT's path is expected not to change.
-        #expect(root.path.count == 2, "The root's path is expected to be empty")
+        #expect(root.path.count == 2, "The root's path is expected to remain unchanged")
     }
     
     @Test func popToInitialRouteErrorNilRoot() {

--- a/Tests/CoordinatorTests/StackCoordinatingTests.swift
+++ b/Tests/CoordinatorTests/StackCoordinatingTests.swift
@@ -20,11 +20,11 @@ import SwiftUI
         let sut = MockStackCoordinator()
         
         // WHEN: A root coordinator is initialized with the SUT.
-        let root = RootStackCoordinator(coordinator: sut)
+        let root = NavigationPathManager(coordinator: sut)
         
         // THEN: The SUT's root is set.
         #expect(sut.root != nil, "Root is expected to be non-nil")
-        let sutRoot = try #require(sut.root as? RootStackCoordinator<MockRoute>, "Root is expected to have type RootStackCoordinator")
+        let sutRoot = try #require(sut.root as? NavigationPathManager<MockRoute>, "Root is expected to have type RootStackCoordinator")
         #expect(sutRoot.initialRoute == root.initialRoute, "Initial routes are expected to match")
     }
     
@@ -34,10 +34,10 @@ import SwiftUI
         let sut = MockStackCoordinator(presentedRoutes: presentedRoutes)
         
         // WHEN: A root coordinator is initialized with the SUT.
-        let root = RootStackCoordinator(coordinator: sut)
+        let root = NavigationPathManager(coordinator: sut)
         
         // THEN: The root coordinator's path matches the SUT's path.
-        let sutRoot = try #require(sut.root as? RootStackCoordinator<MockRoute>, "Root is expected to have type RootStackCoordinator")
+        let sutRoot = try #require(sut.root as? NavigationPathManager<MockRoute>, "Root is expected to have type RootStackCoordinator")
         #expect(sut.presentedRoutes.count == root.path.count, "SUT and root presentedRoutes's are expected to be equal")
         #expect(sutRoot.initialRoute == root.initialRoute, "Initial routes are expected to match")
     }
@@ -47,7 +47,7 @@ import SwiftUI
     @Test func testPushCoordinatorSuccess() {
         // GIVEN: An initialized coordinator (SUT) & root coordinator.
         let sut = MockStackCoordinator()
-        let root = RootStackCoordinator(coordinator: sut)
+        let root = NavigationPathManager(coordinator: sut)
 
         // WHEN: A child coordinator is pushed.
         let child = MockStackCoordinator(initialRoute: .route5)
@@ -77,7 +77,7 @@ import SwiftUI
     @Test func testPushRouteSuccess() {
         // GIVEN: An initialized coordinator (SUT) & root coordinator.
         let sut = MockStackCoordinator()
-        let root = RootStackCoordinator(coordinator: sut)
+        let root = NavigationPathManager(coordinator: sut)
         
         // WHEN: A route is pushed.
         let route = MockRoute.route2
@@ -108,7 +108,7 @@ import SwiftUI
         // GIVEN: An initialized coordinator (SUT) & root coordinator.
         let presentedRoutes = [MockRoute.route1, MockRoute.route2]
         let sut = MockStackCoordinator(presentedRoutes: presentedRoutes)
-        let root = RootStackCoordinator(coordinator: sut)
+        let root = NavigationPathManager(coordinator: sut)
         #expect(sut.presentedRoutes == presentedRoutes, "SUT presentedRoutes is expected to equal the initial presentedRoutes")
         #expect(root.path.count == presentedRoutes.count, "Root path is expected to equal the initial presentedRoutes")
         
@@ -126,7 +126,7 @@ import SwiftUI
     @Test func testPopRouteErrorEmptyPath() {
         // GIVEN: An initialized coordinator (SUT) & root coordinator without an initial path.
         let sut = MockStackCoordinator()
-        let root = RootStackCoordinator(coordinator: sut)
+        let root = NavigationPathManager(coordinator: sut)
         
         // WHEN: A route is popped.
         sut.pop()
@@ -154,7 +154,7 @@ import SwiftUI
         // GIVEN: An initialized coordinator (SUT) & root coordinator with an initial path.
         let presentedRoutes = [MockRoute.route1, MockRoute.route2]
         let sut = MockStackCoordinator(presentedRoutes: presentedRoutes)
-        let root = RootStackCoordinator(coordinator: sut)
+        let root = NavigationPathManager(coordinator: sut)
         
         // WHEN: The SUT pop to initial route.
         sut.popToInitialRoute()
@@ -169,7 +169,7 @@ import SwiftUI
     @Test func testPopToInitialRouteSuccessEmptyPath() {
         // GIVEN: An initialized coordinator (SUT) & root coordinator without an initial path.
         let sut = MockStackCoordinator()
-        let root = RootStackCoordinator(coordinator: sut)
+        let root = NavigationPathManager(coordinator: sut)
         
         // WHEN: The SUT pop to initial route.
         sut.popToInitialRoute()


### PR DESCRIPTION
Fixes the path inconsistency which can arise when posing via the "Back" navigation button.

In this case the coordinator's `presentedRoutes` gets out-of-sync with the RootStackCoordinator's `path`.


This MR introduces transition indices to mitigate this issue. 