### PR TITLE
Fix initial stack coordinator index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Fixes the initial stack coordinator's index in the `transitionIndices` dictionary
+
 ## 2.0.0
 
 - Introduces common `Coordinating` protocol for all type of coordinators

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To integrate `Coordinator` with your Swift project, specify Coordinator as a dep
 Or you can add the following dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/joseph-grabinger/Coordinator.git", from: "2.0.0")
+.package(url: "https://github.com/joseph-grabinger/Coordinator.git", from: "2.0.1")
 ```
 
 ## Features

--- a/Sources/Coordinator/Coordinators/Stack/NavigationPathManager.swift
+++ b/Sources/Coordinator/Coordinators/Stack/NavigationPathManager.swift
@@ -18,7 +18,7 @@ public final class NavigationPathManager<R: Routable>: StackNavigating {
         didSet {
             guard path.count < oldValue.count else { return }
             transitionIndices = transitionIndices.filter { _, index in
-                return index <= path.count - 1 || index == 0
+                return index <= path.count - 1 || index == initialCoordinatorIndex
             }
         }
     }
@@ -32,13 +32,18 @@ public final class NavigationPathManager<R: Routable>: StackNavigating {
     /// The initial route that this coordinator starts with.
     let initialRoute: R
     
+    // MARK: - Private Properties
+    
+    /// A constant for the transition index of the initial coordinator.
+    private let initialCoordinatorIndex = -1
+    
     // MARK: - Initialization
     
     /// Initializes a new `NavigationPathManager` with the  given coordinator.
     /// - Parameter coordinator: A initial stack-based coordinator.
     public init<C: StackCoordinating>(coordinator: C) where C.Route == R {
         self.initialRoute = coordinator.initialRoute
-        transitionIndices[coordinator.id] = 0
+        transitionIndices[coordinator.id] = initialCoordinatorIndex
         coordinator.root = self
     }
 }
@@ -70,7 +75,7 @@ public extension NavigationPathManager {
             Logger.coordinator.warning("\(self) cannot pop coordinator \(coordinator.description): no transition index found.")
             return
         }
-        guard transitionIndex != 0 else {
+        guard transitionIndex != initialCoordinatorIndex else {
             Logger.coordinator.warning("\(self) cannot pop coordinator \(coordinator.description): as it's the initial coordinator.")
             return
         }
@@ -83,7 +88,7 @@ public extension NavigationPathManager {
             Logger.coordinator.warning("\(self) cannot pop to initial route of \(coordinator.description): no transition index found.")
             return
         }
-        if transitionIndex == 0 {
+        if transitionIndex == initialCoordinatorIndex {
             popToRoot()
         } else {
             let routesToPop = path.count - transitionIndex - 1
@@ -94,7 +99,7 @@ public extension NavigationPathManager {
     func popToRoot() {
         path = NavigationPath()
         transitionIndices = transitionIndices.filter { _, index in
-            return index == 0
+            return index == initialCoordinatorIndex
         }
     }
 }


### PR DESCRIPTION
- Introduces a private `initialCoordinatorIndex` constant in the `NavigationPathManager` (with value `-1` instead of `0`)
- Fixes the index of the initial coordinator within the `transitionIndices`

This subsequently fixes the bug when calling `popToInitialRoute()`  from a subsequent coordinator which was push from the initial route of a `CoordinatedStack`.