### PR TITLE
Fix macOS build errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+- Fixes macOS build error by marking `.fullScreenCover`s as unavailable
+
 ## 2.0.1
 
 - Fixes the initial stack coordinator's index in the `transitionIndices` dictionary

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
 // swift-tools-version: 6.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
@@ -7,14 +6,12 @@ let package = Package(
     name: "Coordinator",
     platforms: [.iOS(.v16), .macOS(.v13)],
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "Coordinator",
-            targets: ["Coordinator"]),
+            targets: ["Coordinator"]
+        ),
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "Coordinator"),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To integrate `Coordinator` with your Swift project, specify Coordinator as a dep
 Or you can add the following dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/joseph-grabinger/Coordinator.git", from: "2.0.1")
+.package(url: "https://github.com/joseph-grabinger/Coordinator.git", from: "2.0.2")
 ```
 
 ## Features

--- a/Sources/Coordinator/Coordinators/Modal/ModalCoordinating.swift
+++ b/Sources/Coordinator/Coordinators/Modal/ModalCoordinating.swift
@@ -21,8 +21,10 @@ public protocol ModalCoordinating: Coordinating {
     /// The route which is currently presented as a sheet, if any.
     var sheet: Route? { get set }
     
+#if !os(macOS)
     /// The route which is currently presented as a full screen cover, if any.
     var fullScreenCover: Route? { get set }
+#endif
 }
 
 // MARK: - Navigation Methods
@@ -44,12 +46,14 @@ public extension ModalCoordinating {
                 return
             }
             sheet = route
+#if !os(macOS)
         case .fullScreenCover:
             guard fullScreenCover == nil else {
                 Logger.coordinator.warning("Cannot present \"\(route)\" as fullScreenCover: \"\(self)\" is already presenting \"\(self.fullScreenCover!)\".")
                 return
             }
             fullScreenCover = route
+#endif
         }
     }
     
@@ -59,8 +63,10 @@ public extension ModalCoordinating {
         switch presentationStyle {
         case .sheet:
             sheet = nil
+#if !os(macOS)
         case .fullScreenCover:
             fullScreenCover = nil
+#endif
         }
     }
 }

--- a/Sources/Coordinator/Coordinators/Modal/ModalPresentationStyle.swift
+++ b/Sources/Coordinator/Coordinators/Modal/ModalPresentationStyle.swift
@@ -12,5 +12,6 @@ public enum ModalPresentationStyle {
     case sheet
     
     /// Presents a full screen `View`, which covers as much of the screen as possible.
+    @available(macOS, unavailable)
     case fullScreenCover
 }

--- a/Sources/Coordinator/ViewModifiers/ModalRoutesModifier.swift
+++ b/Sources/Coordinator/ViewModifiers/ModalRoutesModifier.swift
@@ -22,6 +22,8 @@ struct ModalRoutesModifier<C: ModalCoordinating>: ViewModifier {
     func body(content: Content) -> some View {
         content
             .sheet(item: $coordinator.sheet, onDismiss: onDismiss) { $0 }
+        #if !os(macOS)
             .fullScreenCover(item: $coordinator.fullScreenCover, onDismiss: onDismiss) { $0 }
+        #endif
     }
 }

--- a/Tests/CoordinatorTests/ModalCoordinatingTests.swift
+++ b/Tests/CoordinatorTests/ModalCoordinatingTests.swift
@@ -39,6 +39,7 @@ import SwiftUI
         #expect(sut.sheet == oldSheet)
     }
     
+    @available(macOS, unavailable)
     @Test func testPresentFullScreenCoverSuccess() {
         // GIVEN: An initialized coordinator (SUT).
         let sut = MockModalCoordinator()
@@ -51,6 +52,7 @@ import SwiftUI
         #expect(sut.fullScreenCover == newFullScreenCover)
     }
     
+    @available(macOS, unavailable)
     @Test func testPresentFullScreenCoverError() {
         // GIVEN: An initialized coordinator (SUT) with a presented fullScreenCover.
         let oldFullScreenCover = MockModalRoute.route1
@@ -76,12 +78,15 @@ import SwiftUI
         #expect(sut.sheet == nil)
     }
     
+    @available(macOS, unavailable)
     @Test func testDismissFullScreenCover() {
         // GIVEN: An initialized coordinator (SUT) with a presented fullScreenCover.
         let sut = MockModalCoordinator(fullScreenCover: .route1)
         
         // WHEN: The fullScreenCover is dismissed.
+#if !os(macOS)
         sut.dismiss(.fullScreenCover)
+#endif
         
         // THEN: The fullScreenCover is expected to be nil.
         #expect(sut.fullScreenCover == nil)


### PR DESCRIPTION
Fixes the build error which occurred on the macOS platform, by marking `fullScreenCover`s as unavailable on macOS.